### PR TITLE
Idempotent mkdir in docker entry point

### DIFF
--- a/vault/docker-entrypoint.sh
+++ b/vault/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -ex
 
-mkdir /vault/__restricted;
+mkdir -p /vault/__restricted;
 
 status() {
   vault status 2>&1


### PR DESCRIPTION
At the moment it fails to start a docker container when the folder is already created.